### PR TITLE
Remove URL encoding of the hashes to sign

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,15 @@
 # Changelog
 
+## [0.4.0]
+
+_23 Mar 2026_
+
+### Changed:
+- Removed URL-encoding after document digest generation.
+
 ## [0.3.0]
 
-_28 May 2025_
+_1 Jul 2025_
 
 ### Added:
 - Visible representation of the PDF signature.

--- a/src/main/java/eu/europa/ec/eudi/signer/r3/sca/model/signature/SignatureService.java
+++ b/src/main/java/eu/europa/ec/eudi/signer/r3/sca/model/signature/SignatureService.java
@@ -69,8 +69,7 @@ public class SignatureService {
             if (dataToBeSigned == null) continue;
 
             String dataToBeSignedStringEncoded = Base64.getEncoder().encodeToString(dataToBeSigned);
-            String dataToBeSignedURLEncoded = URLEncoder.encode(dataToBeSignedStringEncoded, StandardCharsets.UTF_8);
-            hashes.add(dataToBeSignedURLEncoded);
+            hashes.add(dataToBeSignedStringEncoded);
         }
 
         fileLogger.info("DataToBeSigned successfully created");


### PR DESCRIPTION
### Changed:
- Removed URL-encoding after document digest generation.